### PR TITLE
Don't print "Project root" message in Vim

### DIFF
--- a/src/language_server_protocol.rs
+++ b/src/language_server_protocol.rs
@@ -2751,7 +2751,6 @@ impl LanguageClient {
             .into()
         };
         let message = format!("Project root: {}", root);
-        self.vim()?.echomsg_ellipsis(&message)?;
         info!("{}", message);
         self.update(|state| {
             state.roots.insert(languageId.clone(), root.clone());


### PR DESCRIPTION
There's already the option to print this message to a debug log if you want to, so I don't see the point of always printing `[LC] Project root: ...` in Vim on startup, even if you've configured the logger to only log `WARN` and `ERROR` messages.